### PR TITLE
Switch to psycopg for Postgres support

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -4,6 +4,17 @@ from sqlalchemy.orm import sessionmaker
 from .models import Base
 
 DATABASE_URL = os.getenv("DATABASE_URL")
+
+if DATABASE_URL:
+    if DATABASE_URL.startswith("postgresql://"):
+        DATABASE_URL = DATABASE_URL.replace(
+            "postgresql://", "postgresql+psycopg://", 1
+        )
+    elif DATABASE_URL.startswith("postgres://"):
+        DATABASE_URL = DATABASE_URL.replace(
+            "postgres://", "postgresql+psycopg://", 1
+        )
+
 engine = create_engine(DATABASE_URL, pool_pre_ping=True, pool_size=5, max_overflow=10)
 SessionLocal = sessionmaker(bind=engine, autoflush=False, expire_on_commit=False)
 

--- a/example.toml
+++ b/example.toml
@@ -1,5 +1,5 @@
 OPENAI_API_KEY = "your-openai-api-key"
-DATABASE_URL = "postgresql://user:pass@localhost/db"
+DATABASE_URL = "postgresql+psycopg://user:pass@localhost/db"
 TWILIO_ACCOUNT_SID = "ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 TWILIO_AUTH_TOKEN = "your-twilio-auth-token"
 TWILIO_NUMBER = "+15555555555"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ uvicorn[standard]==0.30.6
 openai>=1.40.0
 pydantic==2.9.0
 SQLAlchemy==2.0.35
-psycopg2-binary==2.9.9
+psycopg[binary]==3.1.18
 sendgrid==6.11.0
 twilio==9.1.0
 python-dotenv==1.0.1


### PR DESCRIPTION
## Summary
- replace psycopg2 dependency with psycopg[binary]
- ensure engine URL uses psycopg driver
- update example configuration for psycopg connection string

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement psycopg==3.1.18)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c807c21edc83208c496c55c35e04f1