### PR TITLE
fix: update psycopg dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ uvicorn[standard]==0.30.6
 openai>=1.40.0
 pydantic==2.9.0
 SQLAlchemy==2.0.35
-psycopg[binary]==3.1.18
+psycopg[binary]==3.2.10
 sendgrid==6.11.0
 twilio==9.1.0
 python-dotenv==1.0.1


### PR DESCRIPTION
## Summary
- bump psycopg[binary] to 3.2.10 for Python 3.13 compatibility

## Testing
- `pip install -r requirements.txt` *(fails: Cannot connect to proxy, no matching distribution found for psycopg==3.2.10)*
- `pytest` *(fails: no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_68c809cfc5c08320b6c0443c94ba42e2