### PR TITLE
fix: use absolute imports for main module

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,8 +1,8 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from .db import init_db
-from .twilio_routes import router as voice_router
-from .ws_handler import router as ws_router
+from app.db import init_db
+from app.twilio_routes import router as voice_router
+from app.ws_handler import router as ws_router
 
 app = FastAPI(title="Dash Movers Voice Agent")
 


### PR DESCRIPTION
## Summary
- use absolute imports in FastAPI `main.py`

## Testing
- `pytest`
- `python -m py_compile app/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68c80b1acfec83209f7e098e09582521