### PR TITLE
Fix package imports for Streamlit execution

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,8 +1,9 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from app.db import init_db
-from app.twilio_routes import router as voice_router
-from app.ws_handler import router as ws_router
+
+from .db import init_db
+from .twilio_routes import router as voice_router
+from .ws_handler import router as ws_router
 
 app = FastAPI(title="Dash Movers Voice Agent")
 


### PR DESCRIPTION
## Summary
- switch the FastAPI entrypoint to use package-relative imports
- allow the module to be executed directly by Streamlit without ModuleNotFoundError

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68cffc5c3ca483209961d278303a0247