### PR TITLE
Use absolute imports in app.main

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,9 +1,9 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from .db import init_db
-from .twilio_routes import router as voice_router
-from .ws_handler import router as ws_router
+from app.db import init_db
+from app.twilio_routes import router as voice_router
+from app.ws_handler import router as ws_router
 
 app = FastAPI(title="Dash Movers Voice Agent")
 


### PR DESCRIPTION
## Summary
- replace relative imports in `app/main.py` with absolute `app.*` imports to avoid ImportError when running under Streamlit

## Testing
- `DATABASE_URL=sqlite:///test.db OPENAI_API_KEY=dummy python -c "import app.main"`

------
https://chatgpt.com/codex/tasks/task_e_68d00159ef488320ac49003cb3b46585