### PR TITLE
Add internal order email webhook endpoint

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2,6 +2,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from .db import init_db
+from .order_routes import router as order_router
 from .twilio_routes import router as voice_router
 from .ws_handler import router as ws_router
 
@@ -16,6 +17,7 @@ app.add_middleware(
 )
 
 app.include_router(voice_router)
+app.include_router(order_router)
 app.include_router(ws_router)
 
 @app.on_event("startup")

--- a/app/order_routes.py
+++ b/app/order_routes.py
@@ -1,0 +1,56 @@
+from uuid import uuid4
+
+from fastapi import APIRouter
+from pydantic import BaseModel, Field
+
+from .db import SessionLocal
+from .models import Order
+
+
+router = APIRouter(tags=["orders"])
+
+
+class OrderEmailPayload(BaseModel):
+    phone: str = Field(..., description="Phone number of the caller")
+    item_details: str = Field(..., description="Clean inventory list provided by the caller")
+    estimate_price: float = Field(..., description="Estimate price calculated for the move")
+    move_date: str = Field(..., description="Move date as provided by the caller")
+    locations: str = Field(..., description="Origin and destination details")
+    estimate_calculation_table: str = Field(
+        ..., description="Full itemized inventory and fee breakdown used for the estimate"
+    )
+    name: str = Field(..., description="Caller first and last name")
+    stairwells: str = Field(..., description="Stairwell/elevator details and floors at each location")
+    email: str = Field(..., description="Caller email address")
+
+
+@router.post("/orders/email")
+def record_order_email(payload: OrderEmailPayload) -> dict:
+    """Record an order request and return a generated reference."""
+    ext_ref = f"ORD-{uuid4().hex[:8].upper()}"
+
+    summary_lines = [
+        f"Name: {payload.name}",
+        f"Phone: {payload.phone}",
+        f"Email: {payload.email}",
+        f"Move date: {payload.move_date}",
+        f"Locations: {payload.locations}",
+        f"Stairwells: {payload.stairwells}",
+        f"Items: {payload.item_details}",
+        f"Estimate price: {payload.estimate_price}",
+        f"Estimate calculation table: {payload.estimate_calculation_table}",
+    ]
+    notes = "\n".join(summary_lines)
+
+    with SessionLocal() as db:
+        order = Order(
+            ext_ref=ext_ref,
+            customer_name=payload.name,
+            status="new lead",
+            eta=payload.move_date,
+            notes=notes,
+        )
+        db.add(order)
+        db.commit()
+
+    return {"status": "received", "order_ref": ext_ref}

--- a/docs/order_email_webhook.json
+++ b/docs/order_email_webhook.json
@@ -1,0 +1,131 @@
+{
+  "type": "webhook",
+  "name": "Order_Email",
+  "description": "Send finalized move leads to the Dash Movers API instead of the legacy Zapier hook.",
+  "disable_interruptions": false,
+  "force_pre_tool_speech": "auto",
+  "assignments": [],
+  "tool_call_sound": null,
+  "tool_call_sound_behavior": "auto",
+  "execution_mode": "immediate",
+  "api_schema": {
+    "url": "https://estimate-moving-price.onrender.com/orders/email",
+    "method": "POST",
+    "path_params_schema": [],
+    "query_params_schema": [],
+    "request_body_schema": {
+      "id": "body",
+      "type": "object",
+      "description": "Submit the caller's contact info, move details, and the fully itemized estimate calculation used.",
+      "properties": [
+        {
+          "id": "phone",
+          "type": "string",
+          "value_type": "llm_prompt",
+          "description": "Phone number of the caller",
+          "dynamic_variable": "",
+          "constant_value": "",
+          "enum": null,
+          "is_system_provided": false,
+          "required": true
+        },
+        {
+          "id": "item_details",
+          "type": "string",
+          "value_type": "llm_prompt",
+          "description": "Clean inventory list the caller provided",
+          "dynamic_variable": "",
+          "constant_value": "",
+          "enum": null,
+          "is_system_provided": false,
+          "required": true
+        },
+        {
+          "id": "estimate_price",
+          "type": "number",
+          "value_type": "llm_prompt",
+          "description": "Final estimate price given to the caller",
+          "dynamic_variable": "",
+          "constant_value": "",
+          "enum": null,
+          "is_system_provided": false,
+          "required": true
+        },
+        {
+          "id": "move_date",
+          "type": "string",
+          "value_type": "llm_prompt",
+          "description": "Move date and whether it falls on a weekday or weekend",
+          "dynamic_variable": "",
+          "constant_value": "",
+          "enum": null,
+          "is_system_provided": false,
+          "required": true
+        },
+        {
+          "id": "locations",
+          "type": "string",
+          "value_type": "llm_prompt",
+          "description": "Origin and destination addresses",
+          "dynamic_variable": "",
+          "constant_value": "",
+          "enum": null,
+          "is_system_provided": false,
+          "required": true
+        },
+        {
+          "id": "estimate_calculation_table",
+          "type": "string",
+          "value_type": "llm_prompt",
+          "description": "Full itemized inventory, weights, fees, and calculation logic",
+          "dynamic_variable": "",
+          "constant_value": "",
+          "enum": null,
+          "is_system_provided": false,
+          "required": true
+        },
+        {
+          "id": "name",
+          "type": "string",
+          "value_type": "llm_prompt",
+          "description": "First and last name of the caller",
+          "dynamic_variable": "",
+          "constant_value": "",
+          "enum": null,
+          "is_system_provided": false,
+          "required": true
+        },
+        {
+          "id": "stairwells",
+          "type": "string",
+          "value_type": "llm_prompt",
+          "description": "Stairwell/elevator info and floors at each location",
+          "dynamic_variable": "",
+          "constant_value": "",
+          "enum": null,
+          "is_system_provided": false,
+          "required": true
+        },
+        {
+          "id": "email",
+          "type": "string",
+          "value_type": "llm_prompt",
+          "description": "Email address of the caller",
+          "dynamic_variable": "",
+          "constant_value": "",
+          "enum": null,
+          "is_system_provided": false,
+          "required": true
+        }
+      ],
+      "required": true,
+      "value_type": "llm_prompt"
+    },
+    "request_headers": [],
+    "auth_connection": null
+  },
+  "response_timeout_secs": 25,
+  "dynamic_variables": {
+    "dynamic_variable_placeholders": {}
+  }
+}


### PR DESCRIPTION
## Summary
- add a FastAPI endpoint to capture order email payloads and persist them as orders
- register the new router with the main application
- document the updated webhook configuration pointing to the internal service

## Testing
- python -m compileall app


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929b15e2a388320a3394ca616053602)